### PR TITLE
Make sunfish a part of coral

### DIFF
--- a/structure.yml
+++ b/structure.yml
@@ -1337,7 +1337,6 @@ OEM-Google:
   - PROJECT-Google-seed
   - PROJECT-Google-shamrock
   - PROJECT-Google-sprout
-  - PROJECT-Google-sunfish
   - PROJECT-Google-wahoo
   - PROJECT-Google-yellowstone
 OEM-HTC:
@@ -1747,7 +1746,10 @@ PROJECT-Generic-goldfish:
 PROJECT-Google-coral:
   - LineageOS/android_device_google_coral
   - LineageOS/android_device_google_flame
+  - LineageOS/android_device_google_sunfish
   - LineageOS/android_kernel_google_coral
+  - LineageOS/android_kernel_google_msm-4.14
+  - LineageOS/android_kernel_google_sunfish
 PROJECT-Google-crosshatch:
   - LineageOS/android_device_google_blueline
   - LineageOS/android_device_google_bonito
@@ -1798,10 +1800,6 @@ PROJECT-Google-sprout:
   - LineageOS/android_device_google_sprout4
   - LineageOS/android_device_google_sprout8
   - LineageOS/android_kernel_mediatek_sprout
-PROJECT-Google-sunfish:
-  - LineageOS/android_device_google_sunfish
-  - LineageOS/android_kernel_google_msm-4.14
-  - LineageOS/android_kernel_google_sunfish
 PROJECT-Google-wahoo:
   - LineageOS/android_device_google_muskie
   - LineageOS/android_device_google_taimen


### PR DESCRIPTION
* This allows coral maintainers permissions on msm-4.14,
   and matches b1c1/b4s4 handling.