### PR TITLE
Update structure.yml

### DIFF
--- a/structure.yml
+++ b/structure.yml
@@ -5,6 +5,7 @@ All-Projects:
   - Lineage-Device-Projects
   - Lineage-Unmaintained-Projects
   - Master-Enabled
+  - Main-Enabled
   - PROJECT-Lineage-telephony
 Head-Developers:
   - LineageOS/android
@@ -1276,6 +1277,7 @@ Master-Enabled:
   - LineageOS/android_external_chromium-webview_prebuilt_arm64
   - LineageOS/android_external_chromium-webview_prebuilt_x86
   - LineageOS/android_external_chromium-webview_prebuilt_x86_64
+Main-Enabled:
   - LineageOS/charter
   - LineageOS/cm_crowdin
   - LineageOS/contributors-cloud-generator


### PR DESCRIPTION
Migrates lineage-owned projects to `main` instead of `master`. 

note: this just disables read on `master` inside gerrit - you can't rename parent groups unfortunately. 