### PR TITLE
master->main

### DIFF
--- a/structure.yml
+++ b/structure.yml
@@ -4,7 +4,7 @@ All-Projects:
   - Lineage-11.0-Projects
   - Lineage-Device-Projects
   - Lineage-Unmaintained-Projects
-  - Master-Enabled
+  - Main-Enabled
   - PROJECT-Lineage-telephony
 Head-Developers:
   - LineageOS/android
@@ -1269,7 +1269,7 @@ Lineage-Unmaintained-Projects:
   - LineageOS/sony-kernel-u8500
   - LineageOS/tools_repo
   - LineageOS/zte-kernel-msm7x27
-Master-Enabled:
+Main-Enabled:
   - LineageOS/android_external_chromium-webview
   - LineageOS/android_external_chromium-webview_patches
   - LineageOS/android_external_chromium-webview_prebuilt_arm


### PR DESCRIPTION
Following google's lead here: https://groups.google.com/g/android-building/c/c2wv8FUxdok/m/78e_OX_qAAAJ

Projects in the `Main-Enabled` group blocks push to refs/heads/master + refs/for/master.